### PR TITLE
Default the repos list in case the store returns a falsy value

### DIFF
--- a/app/src/core/repoSelector.jsx
+++ b/app/src/core/repoSelector.jsx
@@ -134,7 +134,7 @@ function RepoSelector(props) {
   useEffect(() => {
     window.api.store.onReceive(readConfigResponse, function(args){
       if (args.success && args.key === "repos") {
-        dispatch(setRepos(args.value));
+        dispatch(setRepos(args.value || []));
       }
     });
     window.api.store.send(readConfigRequest, "repos");


### PR DESCRIPTION
Fixes #151

The new store was giving back undefined as a starting value which prevented new installs from adding repos.